### PR TITLE
Gzip compression support

### DIFF
--- a/3.4/Pubnub.php
+++ b/3.4/Pubnub.php
@@ -36,8 +36,6 @@ class Pubnub {
      * @param string $origin optional setting for cloud origin.
      * @param string $pem_path
      * @param string $proxy
-     * @param boolean $compress whether gzip compress messages before publishing.
-     * @param int $compress_lvl level of gzip compression to use - 0 for no compression, 9 highest, -1 = use default.
      */
 
     function Pubnub(

--- a/3.4/Pubnub.php
+++ b/3.4/Pubnub.php
@@ -48,17 +48,13 @@ class Pubnub {
         $ssl = false,
         $origin = false,
         $pem_path = false,
-        $proxy = false,
-        $compress = false,
-        $compress_lvl = -1
+        $proxy = false
     ) {
         $this->SESSION_UUID = $this->uuid();
         $this->PUBLISH_KEY = $publish_key;
         $this->SUBSCRIBE_KEY = $subscribe_key;
         $this->SECRET_KEY = $secret_key;
         $this->PROXY = $proxy;
-        $this->COMPRESS = $compress;
-        $this->COMPRESS_LVL = $compress_lvl;
 
         if (!isBlank($cipher_key)) {
             $this->CIPHER_KEY = $cipher_key;
@@ -99,7 +95,7 @@ class Pubnub {
         $message = $this->sendMessage($message_org);
 
         ## Compress if requested
-        if ($args['compress']) {
+        if (isset($args['compress'])) {
             $this->COMPRESS     = $args['compress'];
             $this->COMPRESS_LVL = $args['compress_lvl'] ?: $this->COMPRESS_LVL;
         }
@@ -564,6 +560,19 @@ class Pubnub {
 
     private function setProxy($proxy) {
         $this->PROXY = $proxy;
+    }
+
+    public function useCompression($compress = false, $compress_lvl = -1)  {
+        $this->setCompress($compress);
+        $this->setCompressLvl($compress_lvl);
+    }
+
+    private function setCompress($compress = false) {
+        $this->COMPRESS = $compress;
+    }
+
+    private function setCompressLvl($compress_lvl = -1) {
+        $this->COMPRESS_LVL = $compress_lvl;
     }
 
     /**

--- a/3.4/Pubnub.php
+++ b/3.4/Pubnub.php
@@ -592,5 +592,3 @@ class Pubnub {
             return rawurlencode($char);
     }
 }
-
-?>


### PR DESCRIPTION
Two main changes:
- added two new constructor variables, $compress and $compress_lvl
- added option to specify per-message compression (compress: true)

Two small cleanups:
- fixed docblock so argument order is correct
- removed trailing ?>
