### PR TITLE
Update JSON.php

### DIFF
--- a/composer/lib/Pubnub/JSON.php
+++ b/composer/lib/Pubnub/JSON.php
@@ -16,7 +16,7 @@ class JSON
     public static function decode($val, $assoc = true, $depth = 512, $options = 0)
     {
 
-        return json_decode($val, $assoc, $depth, $options);
+        return json_decode($val, $assoc, $depth);
 
     }
 


### PR DESCRIPTION
the function json_decode got the 4th argument in php 5.4 so this is not php 5.3 compatible
