### PR TITLE
Made logger PSR-3 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "psr/log": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/composer/lib/Pubnub/Pubnub.php
+++ b/composer/lib/Pubnub/Pubnub.php
@@ -5,7 +5,7 @@ namespace Pubnub;
 use Exception;
 use Pubnub\Clients\DefaultClient;
 use Pubnub\Clients\PipelinedClient;
-
+use Psr\Log\LoggerInterface;
 
 /**
  * PubNub 3.8.1 Real-time Push Cloud API
@@ -67,7 +67,8 @@ class Pubnub
         $proxy = false,
         $auth_key = false,
         $verify_peer = true,
-        $gzip = false
+        $gzip = false,
+        LoggerInterface $logger = null
     ) {
 
         if (is_array($first_argument)) {
@@ -83,11 +84,16 @@ class Pubnub
             $auth_key = isset($first_argument['auth_key']) ? $first_argument['auth_key'] : false;
             $verify_peer = isset($first_argument['verify_peer']) ? $first_argument['verify_peer'] : $verify_peer;
             $gzip = isset($first_argument['gzip']) ? $first_argument['gzip'] : false;
+            $logger = isset($first_argument['logger']) ? $first_argument['logger'] : null;
         } else {
             $publish_key = $first_argument;
         }
 
-        $this->logger = new PubnubLogger("Pubnub");
+        if ($logger == null) {
+            $logger = new PubnubLogger("Pubnub");
+        }
+
+        $this->logger = $logger;
 
         if (empty($subscribe_key)) {
             throw new PubnubException('Missing required $subscribe_key param');

--- a/composer/lib/Pubnub/PubnubLogger.php
+++ b/composer/lib/Pubnub/PubnubLogger.php
@@ -2,7 +2,10 @@
 
 namespace Pubnub;
 
-class PubnubLogger
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class PubnubLogger implements LoggerInterface
 {
     private $logDebugMessages = false;
     private $className = "";
@@ -11,12 +14,45 @@ class PubnubLogger
         $this->className = $className;
     }
 
-    public function debug($message)
-    {
+    public function emergency($message, array $context = array()) {
+
+    }
+
+    public function alert($message, array $context = array()) {
+
+    }
+
+    public function critical($message, array $context = array()) {
+
+    }
+
+    public function error($message, array $context = array()) {
+
+    }
+
+    public function warning($message, array $context = array()) {
+
+    }
+
+    public function notice($message, array $context = array()) {
+
+    }
+
+    public function info($message, array $context = array()) {
+
+    }
+
+    public function debug($message, array $context = array()) {
         if ($this->logDebugMessages) {
             echo $this->className . "::DEBUG:: ";
             print_r($message);
             echo "\n";
+        }
+    }
+
+    public function log($level, $message, array $context = array()) {
+        if ($level === LogLevel::DEBUG) {
+            $this->debug($message, $context);
         }
     }
 


### PR DESCRIPTION
Hi!

I thought it might be useful to make the current logger PSR-3 compatible, and make it injectable. That way framework integrations etc. can inject their own loggers instead of the default one.
