### PR TITLE
To fix a bug for presence to a channel group

### DIFF
--- a/composer/lib/Pubnub/Pubnub.php
+++ b/composer/lib/Pubnub/Pubnub.php
@@ -388,6 +388,29 @@ class Pubnub
 
         $this->_subscribe(null, $group, $callback, $timetoken, false, $timeoutHandler);
     }
+    
+    /**
+     * Presence to channel group -- New added by Wangdiwen.
+     *
+     * @param string|array $group to subscribe
+     * @param callable $callback to invoke on success
+     * @throws PubnubException
+     */
+    public function channelGroupPresence($group, $callback)
+    {
+        if (empty($group)) {
+            throw new PubnubException("Missing Group in channelGroupSubscribe()");
+        }
+        
+        // Add the presence suffix automaticly
+        if (! PubnubUtil::string_ends_with($group, static::PRESENCE_SUFFIX)) {
+            $group = $group . static::PRESENCE_SUFFIX;
+        }
+        
+        // Also invoke the '_subscribe' function,
+        // the 5th parameter set to true because it satisfied the meaning of presence to channel group.
+        $this->_subscribe(null, $group, $callback, 0, true, null);
+    }
 
     protected function _subscribe($channel, $channelGroup, $callback, $timeToken = 0, $presence = false,
         $timeoutHandler = null)
@@ -1264,7 +1287,8 @@ class Pubnub
         // if presence message while only subscribe
         if (
             PubnubUtil::string_ends_with($channel, static::PRESENCE_SUFFIX)
-            && !in_array($group, $WCPresenceChannels)
+            // && !in_array($group, $WCPresenceChannels)
+            && !in_array($group, $WCPresenceChannels) && !in_array($group, $CGs)    // Fix it, new added by Wangdiwen.
         ) {
             $logger->debug("WC presence message on " . $channel . " while is not subscribe for presence");
             return false;


### PR DESCRIPTION
Hi Maintainers of PHP-SDK,

I found a problem when presence to a channel group, and I think maybe it was a bug.

Issue:
The snippet code is below:

> $channel_group = "family";
> ... // Omit other codes here.
> $pn->channelGroupSubscribe($channel_group . '-pnpres', function ($message) {
> print_r($message);
> return true;
> }

The problem is this function cannot receive any join or leave event, so I analyzed the interface of "channelGroupSubscribe", and I found "shouldComplexMessageBePassedToUserCallback" function always return false.

When presence to a channel group , the variables "$WCSubscribeChannels" and "$WCPresenceChannels" are both an empty array because the parameter "$channel" is null.
In the interface of "shouldComplexMessageBePassedToUserCallback", it will always return false even if the parameter "$group" in "$CGs" array.

By the way, I think the 5th parameter "$presence" can set to true when using "channelGroupSubscribe" function, so I wrote a new interface named "channelGroupPresence" and it also invoke the "_subscribe" func.

Regards.
Steven