### PR TITLE
Fix urlencode issue with channel names.

### DIFF
--- a/src/PubNub/Endpoints/Endpoint.php
+++ b/src/PubNub/Endpoints/Endpoint.php
@@ -203,6 +203,10 @@ abstract class Endpoint
             $params['auth'] = PubNubUtil::urlEncode($params['auth']);
         }
 
+        if (array_key_exists('channel', $params)) {
+            $params['channel'] = PubNubUtil::urlEncode($params['channel']);
+        }
+
         return $params;
     }
 


### PR DESCRIPTION
Channel name's should be urlencoded to handle special characters like '#' which the ChatEngine js api uses for it's namespacing.
From what I can see from the REST API documentation for AccessManager( access here: https://www.pubnub.com/docs/pubnub-rest-api-documentation#header-access-manager-request-string-required-formatting) the PHP api is not handling this properly.

When I attempted to use a channel name such as 'chat-engine#' the api would throw a 400 error saying the timestamp was not found.  Adding a urlencode in Endpoint fixes this.  Note the customParams is supposed to urlencode this properly, however if you do that the PAM signature builder throws an error saying the signature doesn't match.  There may be a better place to handle this properly so you can reject the pull request and fix it properly or accept this if the solution is adequate.