### PR TITLE
Fix issue with getting state for a single channel group

### DIFF
--- a/src/PubNub/Endpoints/Presence/GetState.php
+++ b/src/PubNub/Endpoints/Presence/GetState.php
@@ -103,6 +103,8 @@ class GetState extends Endpoint
     {
         if (count($this->channels) === 1 && count($this->channelGroups) === 0) {
             $channels = [$this->channels[0] => $json['payload']];
+        } else if (count($this->channels) === 0 && count($this->channelGroups) === 1) {
+            $channels = [$this->channelGroups[0] => $json['payload']];
         } else {
             $channels = $json['payload']['channels'];
         }


### PR DESCRIPTION
When trying to get the state of a channel group the response contained just the state rather than an array of channels as expected. There was a workaround for when getting the state for a single channel but not for a single channel group.