### PR TITLE
Fix slow publish issue

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: php
-version: 4.1.0
+version: 4.1.2
 schema: 1
 scm: github.com/pubnub/php
 changelog:
+  - version: 4.1.2
+    date: Oct 23, 2018
+    changes:
+      - type: bug
+        text: Fix issue with deleteMessages endpoint using GET HTTP method instead of DELETE
   - version: 4.1.1
     date: Oct 2, 2018
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -112,6 +112,7 @@ features:
     - STORAGE-INCLUDE-TIMETOKEN
     - STORAGE-START-END
     - STORAGE-COUNT
+    - STORAGE-MESSAGE-COUNT
   time:
     - TIME-TIME
   subscribe:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: php
-version: 4.1.2
+version: 4.1.3
 schema: 1
 scm: github.com/pubnub/php
 changelog:
+  - version: 4.1.3
+    date: Feb 28, 2019
+    changes:
+      - type: feature
+        text: Add messageCounts() method for retrieving unread message count
   - version: 4.1.2
     date: Oct 23, 2018
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,6 +3,13 @@ version: 4.1.3
 schema: 1
 scm: github.com/pubnub/php
 changelog:
+  - version: 4.1.4
+    date: Oct 18, 2019
+    changes:
+      - type: bug
+        text: Add support for request transport reusing to resolve slow publish issues when multiple messages are published consecutively.
+      - type: bug
+        text: Drop support for HHVM.
   - version: 4.1.3
     date: Feb 28, 2019
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: php
-version: 4.1.3
+version: 4.1.4
 schema: 1
 scm: github.com/pubnub/php
 changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v4.1.3](https://github.com/pubnub/php/tree/v4.1.3)
+ February-28-2019
+
+- ⭐Add messageCounts() method for retrieving unread message count
+
 ## [v4.1.2](https://github.com/pubnub/php/tree/v4.1.2)
  October-23-2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v4.1.4](https://github.com/pubnub/php/tree/v4.1.4)
+ October-18-2019
+
+- 🐛Add support for request transport reusing to resolve slow publish issues when multiple messages are published consecutively.
+- 🐛Drop support for HHVM.
+
 ## [v4.1.3](https://github.com/pubnub/php/tree/v4.1.3)
  February-28-2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v4.1.2](https://github.com/pubnub/php/tree/v4.1.2)
+ October-23-2018
+
+- 🐛Fix issue with deleteMessages endpoint using GET HTTP method instead of DELETE
+
 ## [v4.1.1](https://github.com/pubnub/php/tree/v4.1.1)
  October-2-2018
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["api", "real-time", "realtime", "real time", "ajax", "push"],
   "homepage": "http://www.pubnub.com/",
   "license": "MIT",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "authors": [
     {
       "name": "PubNub",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["api", "real-time", "realtime", "real time", "ajax", "push"],
   "homepage": "http://www.pubnub.com/",
   "license": "MIT",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "authors": [
     {
       "name": "PubNub",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["api", "real-time", "realtime", "real time", "ajax", "push"],
   "homepage": "http://www.pubnub.com/",
   "license": "MIT",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "authors": [
     {
       "name": "PubNub",

--- a/src/PubNub/Endpoints/MessageCount.php
+++ b/src/PubNub/Endpoints/MessageCount.php
@@ -26,9 +26,9 @@ class MessageCount extends Endpoint
      * @param string|array $ch
      * @return $this
      */
-    public function channels($ch)
+    public function channels($channels)
     {
-        $this->channels = PubNubUtil::extendArray($this->channels, $ch);
+        $this->channels = PubNubUtil::extendArray($this->channels, $channels);
 
         return $this;
     }
@@ -141,17 +141,15 @@ class MessageCount extends Endpoint
     {
         $params = [];
 
-        if (count($this->channelsTimetoken) > 0) {
-            if(count($this->channelsTimetoken) > 1)
-                $params['channelsTimetoken'] = PubNubUtil::joinItems($this->channelsTimetoken);
-            else
-            {
-                $params['timetoken'] = $this->channelsTimetoken[0];
-            }
-
+        if (count($this->channelsTimetoken) > 1) {
+            $params['channelsTimetoken'] = PubNubUtil::joinItems($this->channelsTimetoken);
         }
-        else
+        else if(count($this->channelsTimetoken) === 1) {
+            $params['timetoken'] = $this->channelsTimetoken[0];
+        }
+        else {
             $params['timetoken'] = $this->timetoken;
+        }
 
         return $params;
     }

--- a/src/PubNub/PubNub.php
+++ b/src/PubNub/PubNub.php
@@ -32,7 +32,7 @@ use PubNub\Managers\TelemetryManager;
 
 class PubNub
 {
-    const SDK_VERSION = "4.1.2";
+    const SDK_VERSION = "4.1.3";
     const SDK_NAME = "PubNub-PHP";
 
     public static $MAX_SEQUENCE = 65535;

--- a/src/PubNub/PubNub.php
+++ b/src/PubNub/PubNub.php
@@ -32,7 +32,7 @@ use PubNub\Managers\TelemetryManager;
 
 class PubNub
 {
-    const SDK_VERSION = "4.1.3";
+    const SDK_VERSION = "4.1.4";
     const SDK_NAME = "PubNub-PHP";
 
     public static $MAX_SEQUENCE = 65535;

--- a/src/PubNub/PubNub.php
+++ b/src/PubNub/PubNub.php
@@ -31,7 +31,7 @@ use PubNub\Managers\TelemetryManager;
 
 class PubNub
 {
-    const SDK_VERSION = "4.1.1";
+    const SDK_VERSION = "4.1.2";
     const SDK_NAME = "PubNub-PHP";
 
     public static $MAX_SEQUENCE = 65535;


### PR DESCRIPTION
- Add support for request transport reusing to resolve slow publish issues when multiple messages are published consecutively.
- Drop HHVM support.
- Bump version to v4.1.4.