### PR TITLE
Dependencies Versions Update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
   },
   "require": {
     "php": ">=5.6.0",
-    "rmccue/requests": ">=1.0",
-    "monolog/monolog": "^1.0"
+    "rmccue/requests": "^1.0",
+    "monolog/monolog": "^1.1|^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
For `monolog/monolog`: Permit version 2, because your project don't have incompatibilities
For `rmccue/requests`: The version constraint has no upper bound - this is not a good idea. See https://getcomposer.org/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md for more information