### PR TITLE
Default usePost to true

### DIFF
--- a/src/PubNub/Endpoints/PubSub/Publish.php
+++ b/src/PubNub/Endpoints/PubSub/Publish.php
@@ -26,7 +26,7 @@ class Publish extends Endpoint
     protected $shouldStore;
 
     /** @var bool $usePost HTTP method instead of default GET  */
-    protected $usePost;
+    protected $usePost = true;
 
     /** @var  array $meta data */
     protected $meta;

--- a/tests/functional/PublishTest.php
+++ b/tests/functional/PublishTest.php
@@ -69,7 +69,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                $usePost ? Publish::POST_PATH : Publish::GET_PATH,
+                $usePost ? "/publish/%s/%s/0/%s/0" : "/publish/%s/%s/0/%s/0/%s",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -137,7 +137,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                Publish::POST_PATH,
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -177,7 +177,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                Publish::POST_PATH,
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -217,7 +217,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                Publish::POST_PATH,
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -257,7 +257,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                Publish::POST_PATH,
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -295,7 +295,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                Publish::POST_PATH,
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,

--- a/tests/functional/PublishTest.php
+++ b/tests/functional/PublishTest.php
@@ -69,7 +69,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                $usePost ? "/publish/%s/%s/0/%s/0" : "/publish/%s/%s/0/%s/0/%s",
+                $usePost ? Publish::POST_PATH : Publish::GET_PATH,
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -137,7 +137,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0",
+                Publish::POST_PATH,
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -177,7 +177,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0",
+                Publish::POST_PATH,
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -217,7 +217,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0",
+                Publish::POST_PATH,
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -257,7 +257,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0",
+                Publish::POST_PATH,
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -295,7 +295,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0",
+                Publish::POST_PATH,
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,

--- a/tests/functional/PublishTest.php
+++ b/tests/functional/PublishTest.php
@@ -93,12 +93,12 @@ class PublishTest extends \PubNubTestCase
 
     private function assertGeneratesCorrectPathUsingGet($message, $channel, $sequenceNumber)
     {
-        $this->assertGeneratesCorrectPath($message, $channel, false, $sequenceNumber);
+        $this->assertGeneratesCorrectPath($message, $channel, true, $sequenceNumber);
     }
 
     private function assertGeneratesCorrectPathUsingPost($message, $channel, $sequenceNumber)
     {
-        $this->assertGeneratesCorrectPath($message, $channel, false, $sequenceNumber);
+        $this->assertGeneratesCorrectPath($message, $channel, true, $sequenceNumber);
     }
 
     public function testPublishGet()
@@ -137,7 +137,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0/%s",
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -177,7 +177,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0/%s",
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -217,7 +217,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0/%s",
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -257,7 +257,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0/%s",
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,
@@ -295,7 +295,7 @@ class PublishTest extends \PubNubTestCase
 
         $this->assertEquals(
             sprintf(
-                "/publish/%s/%s/0/%s/0/%s",
+                "/publish/%s/%s/0/%s/0",
                 $this->pubnub->getConfiguration()->getPublishKey(),
                 $this->pubnub->getConfiguration()->getSubscribeKey(),
                 $channel,


### PR DESCRIPTION
usePost is currently defaulted to false. For some requests, the url passed along in the request is too long to be handled by a GET call. 
As all requests currently _**CANNOT**_ be handled by the default GET (when usePost = false), this defaults it to **true**