### PR TITLE
Update Grant endpoint to allow setting of delete permissions

### DIFF
--- a/src/PubNub/Endpoints/Access/Grant.php
+++ b/src/PubNub/Endpoints/Access/Grant.php
@@ -32,6 +32,9 @@ class Grant extends Endpoint
     /** @var  bool */
     protected $manage;
 
+    /** @var  bool */
+    protected $delete;
+
     /** @var  int */
     protected $ttl;
 
@@ -98,6 +101,17 @@ class Grant extends Endpoint
 
         return $this;
     }
+    
+    /**
+     * @param bool $flag
+     * @return $this
+     */
+    public function delete($flag)
+    {
+        $this->delete = $flag;
+
+        return $this;
+    }
 
     /**
      * Set time in minutes for which granted permissions are valid
@@ -148,6 +162,10 @@ class Grant extends Endpoint
 
         if ($this->manage !== null) {
             $params["m"] = ($this->manage) ? "1" : "0";
+        }
+
+        if ($this->delete !== null) {
+            $params["d"] = ($this->delete) ? "1" : "0";
         }
 
         if (count($this->authKeys) > 0) {


### PR DESCRIPTION
This is to allows for setting the delete permission using the access manager.

The delete feature is important for allowing auth keys to be able to delete messages and more importantly, message actions for things like 'reactions' which should be able to be reversed (e.g. unliking something).

Not having this permission exposed in the PHP SDK means that customers using PHP for their access management are unable to take advantage of this feature.