### PR TITLE
GCM is now FCM

### DIFF
--- a/src/PubNub/Endpoints/Push/AddChannelsToPush.php
+++ b/src/PubNub/Endpoints/Push/AddChannelsToPush.php
@@ -60,6 +60,12 @@ class AddChannelsToPush extends Endpoint
      */
     public function pushType($pushType)
     {
+        // FCM is new, GCM is still used internally
+        if( $pushType == PNPushType::FCM )
+        {
+            $pushType = PNPushType::GCM;
+        }
+
         $this->pushType = $pushType;
 
         return $this;

--- a/src/PubNub/Endpoints/Push/ListPushProvisions.php
+++ b/src/PubNub/Endpoints/Push/ListPushProvisions.php
@@ -45,6 +45,12 @@ class ListPushProvisions extends Endpoint
      */
     public function pushType($pushType)
     {
+        // FCM is new, GCM is still used internally
+        if( $pushType == PNPushType::FCM )
+        {
+            $pushType = PNPushType::GCM;
+        }
+
         $this->pushType = $pushType;
 
         return $this;

--- a/src/PubNub/Endpoints/Push/RemoveChannelsFromPush.php
+++ b/src/PubNub/Endpoints/Push/RemoveChannelsFromPush.php
@@ -60,6 +60,12 @@ class RemoveChannelsFromPush extends Endpoint
      */
     public function pushType($pushType)
     {
+        // FCM is new, GCM is still used internally
+        if( $pushType == PNPushType::FCM )
+        {
+            $pushType = PNPushType::GCM;
+        }
+
         $this->pushType = $pushType;
 
         return $this;

--- a/src/PubNub/Endpoints/Push/RemoveDeviceFromPush.php
+++ b/src/PubNub/Endpoints/Push/RemoveDeviceFromPush.php
@@ -45,6 +45,12 @@ class RemoveDeviceFromPush extends Endpoint
      */
     public function pushType($pushType)
     {
+        // FCM is new, GCM is still used internally
+        if( $pushType == PNPushType::FCM )
+        {
+            $pushType = PNPushType::GCM;
+        }
+
         $this->pushType = $pushType;
 
         return $this;

--- a/src/PubNub/Enums/PNPushType.php
+++ b/src/PubNub/Enums/PNPushType.php
@@ -9,4 +9,6 @@ class PNPushType
     const APNS2 = "apns2";
     const MPNS = "mpns";
     const GCM = "gcm";
+    // FCM is the new name of GCM. Pubnub still requires 'gcm'
+    const FCM = "gcm";
 }

--- a/src/PubNub/Enums/PNPushType.php
+++ b/src/PubNub/Enums/PNPushType.php
@@ -9,6 +9,5 @@ class PNPushType
     const APNS2 = "apns2";
     const MPNS = "mpns";
     const GCM = "gcm";
-    // FCM is the new name of GCM. Pubnub still requires 'gcm'
-    const FCM = "gcm";
+    const FCM = "fcm";
 }


### PR DESCRIPTION
GCM is now FCM.
Pubnub still requires GCM but should allow for FCM constants and the SDK could internally set this to GCM.