### PR TITLE
Add PHP 8.2 compatibility

### DIFF
--- a/src/PubNub/Managers/SubscriptionManager.php
+++ b/src/PubNub/Managers/SubscriptionManager.php
@@ -33,6 +33,9 @@ class SubscriptionManager
     /** @var  ListenerManager */
     protected $listenerManager;
 
+    /** @var  StateManager */
+    protected $subscriptionState;
+
     /** @var  int */
     protected $timetoken;
 

--- a/src/PubNub/PubNubUtil.php
+++ b/src/PubNub/PubNubUtil.php
@@ -172,8 +172,8 @@ class PubNubUtil
     {
         $result = strtr(base64_encode(hash_hmac(
             'sha256',
-            utf8_encode($signInput),
-            utf8_encode($secret),
+            self::convertIso8859ToUtf8($signInput),
+            self::convertIso8859ToUtf8($secret),
             true
         )), '+/', '-_');
 
@@ -251,5 +251,21 @@ class PubNubUtil
     public static function tokenEncode($token)
     {
         return str_replace('+', '%20', urlencode($token));
+    }
+
+    private static function convertIso8859ToUtf8($s)
+    {
+        $s .= $s;
+        $len = strlen($s);
+
+        for ($i = $len >> 1, $j = 0; $i < $len; ++$i, ++$j) {
+            switch (true) {
+                case $s[$i] < "\x80": $s[$j] = $s[$i]; break;
+                case $s[$i] < "\xC0": $s[$j] = "\xC2"; $s[++$j] = $s[$i]; break;
+                default: $s[$j] = "\xC3"; $s[++$j] = chr(ord($s[$i]) - 64); break;
+            }
+        }
+
+        return substr($s, 0, $j);
     }
 }


### PR DESCRIPTION
Fixes:
* [PHP 8.2: Dynamic Properties are deprecated](https://php.watch/versions/8.2/dynamic-properties-deprecated)
* [PHP 8.2: utf8_encode and utf8_decode functions deprecated](https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated)