### PR TITLE
Fix PHP 8.2 compatibility

### DIFF
--- a/src/PubNub/PubNubUtil.php
+++ b/src/PubNub/PubNubUtil.php
@@ -173,8 +173,8 @@ class PubNubUtil
     {
         $result = strtr(base64_encode(hash_hmac(
             'sha256',
-            utf8_encode($signInput),
-            utf8_encode($secret),
+            self::convertIso8859ToUtf8($signInput),
+            self::convertIso8859ToUtf8($secret),
             true
         )), '+/', '-_');
 
@@ -252,5 +252,21 @@ class PubNubUtil
     public static function tokenEncode($token)
     {
         return str_replace('+', '%20', urlencode($token));
+    }
+
+    private static function convertIso8859ToUtf8($s)
+    {
+        $s .= $s;
+        $len = strlen($s);
+
+        for ($i = $len >> 1, $j = 0; $i < $len; ++$i, ++$j) {
+            switch (true) {
+                case $s[$i] < "\x80": $s[$j] = $s[$i]; break;
+                case $s[$i] < "\xC0": $s[$j] = "\xC2"; $s[++$j] = $s[$i]; break;
+                default: $s[$j] = "\xC3"; $s[++$j] = chr(ord($s[$i]) - 64); break;
+            }
+        }
+
+        return substr($s, 0, $j);
     }
 }


### PR DESCRIPTION
Follows https://github.com/pubnub/php/pull/73, because issue has not been fully addressed in https://github.com/pubnub/php/pull/72 despite it was said by @parfeon 

Fixes:
* [PHP 8.2: utf8_encode and utf8_decode functions deprecated](https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated)

Implementation of `convertIso8859ToUtf8` method was taken from the well-known `symfony/polyfill-php72` package: https://github.com/symfony/polyfill-php72/blob/main/Php72.php#L24-L38