### PR TITLE
fix compatibility issues with php8.2

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,15 @@
 name: php
-version: 6.0.0
+version: 6.0.1
 schema: 1
 scm: github.com/pubnub/php
 changelog:
+  - date: 2023-05-18
+    version: v6.0.1
+    changes:
+      - type: bug
+        text: "Support for Monolog/Monolog@^3.0."
+      - type: bug
+        text: "Added Monolog ^3.0 to developer dependencies and updated developer.md Closes #79 Added replacement for deprecated utf8_decode method. Closes #78."
   - date: 2023-02-01
     version: v6.0.0
     changes:
@@ -378,8 +385,8 @@ sdks:
                     - x86-64
           - distribution-type: library
             distribution-repository: GitHub release
-            package-name: php-6.0.0.zip
-            location: https://github.com/pubnub/php/releases/tag/v6.0.0
+            package-name: php-6.0.1.zip
+            location: https://github.com/pubnub/php/releases/tag/v6.0.1
             requires:
               - name: rmccue/requests
                 min-version: 1.0.0

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -9,7 +9,7 @@ changelog:
       - type: bug
         text: "Support for Monolog/Monolog@^3.0."
       - type: bug
-        text: "Added Monolog ^3.0 to developer dependencies and updated developer.md Closes #79 Added replacement for deprecated utf8_decode method. Closes #78."
+        text: "Added replacement for deprecated utf8_decode method."
   - date: 2023-02-01
     version: v6.0.0
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ May 18 2023
 
 #### Fixed
 - Support for Monolog/Monolog@^3.0.
-- Added Monolog ^3.0 to developer dependencies and updated developer.md Closes #79 Added replacement for deprecated utf8_decode method. Closes #78.
+- Added replacement for deprecated utf8_decode method.
 
 ## v6.0.0
 February 01 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v6.0.1
+May 18 2023
+
+#### Fixed
+- Support for Monolog/Monolog@^3.0.
+- Added Monolog ^3.0 to developer dependencies and updated developer.md Closes #79 Added replacement for deprecated utf8_decode method. Closes #78.
+
 ## v6.0.0
 February 01 2023
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -15,7 +15,7 @@ You can find that PHP support threads and event loop libraries, but all of them 
 Requests library [https://github.com/rmccue/Requests] is a wrapper over raw cURL requests.
 
 ### Monolog (logging library)
-We should review Monolog usage and remove the dependency if possible. Developers who don't use composer encountering problems with manual installation, so the better solution is to get rid of this extra dependency and provide another logging solution.
+Monolog has been removed from `PubNub` instance and has been replaced by `Psr\Log\NullLogger`. Now any logger that implements `Psr\Log\LoggerInterface` can be used after setting it to existing `PubNub` instance through a `setLogger(LoggerInterface $logger)` method.
 
 ## Tests
 There are 3 type of tests:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
          {
              "require": {
                  <!-- include the latest version from the badge at the top -->
-                 "pubnub/pubnub": "6.0.0"
+                 "pubnub/pubnub": "6.0.1"
              }
          }
          ```

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "psr/log": "^1.1|^2.0|^3.0"
   },
   "require-dev": {
-    "monolog/monolog": "^2.8",
+    "monolog/monolog": "^2.9 || ^3.0",
     "phpunit/phpunit": "^9.5",
     "squizlabs/php_codesniffer": "^3.7",
     "phpstan/phpstan": "^1.8"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["api", "real-time", "realtime", "real time", "ajax", "push"],
   "homepage": "http://www.pubnub.com/",
   "license": "MIT",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "authors": [
     {
       "name": "PubNub",

--- a/src/PubNub/PubNub.php
+++ b/src/PubNub/PubNub.php
@@ -53,7 +53,7 @@ use Psr\Log\NullLogger;
 
 class PubNub implements LoggerAwareInterface
 {
-    protected const SDK_VERSION = "6.0.0";
+    protected const SDK_VERSION = "6.0.1";
     protected const SDK_NAME = "PubNub-PHP";
 
     public static $MAX_SEQUENCE = 65535;


### PR DESCRIPTION
fix: support for Monolog/Monolog@^3.0
Added Monolog ^3.0 to developer dependencies and updated developer.md
Closes #79
fix: add replacement for deprecated utf8_decode with implementation taken from the well-known symfony/polyfill-php72 package
Added replacement for deprecated utf8_decode method.
Closes #78