### PR TITLE
Fix/handle unencrypted message

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: php
-version: 6.1.2
+version: 6.1.3
 schema: 1
 scm: github.com/pubnub/php
 changelog:
+  - date: 2023-11-27
+    version: v6.1.3
+    changes:
+      - type: bug
+        text: "Gracefully handle decrypting an unencrypted method. If decryption error occurs when trying to decrypt a plain text the plain text message will be returned and error field will be set in the response. This works both for history and subscription messages."
   - date: 2023-11-02
     version: v6.1.2
     changes:
@@ -402,8 +407,8 @@ sdks:
                     - x86-64
           - distribution-type: library
             distribution-repository: GitHub release
-            package-name: php-6.1.2.zip
-            location: https://github.com/pubnub/php/releases/tag/v6.1.2
+            package-name: php-6.1.3.zip
+            location: https://github.com/pubnub/php/releases/tag/v6.1.3
             requires:
               - name: rmccue/requests
                 min-version: 1.0.0

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -7,7 +7,7 @@ changelog:
     version: v6.1.3
     changes:
       - type: bug
-        text: "Gracefully handle decrypting an unencrypted method. If decryption error occurs when trying to decrypt a plain text the plain text message will be returned and error field will be set in the response. This works both for history and subscription messages."
+        text: "Gracefully handle decrypting an unencrypted method. If a decryption error occurs when trying to decrypt plain text, the plain text message will be returned and an error field will be set in the response. This works for both history and subscription messages."
   - date: 2023-11-02
     version: v6.1.2
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 November 27 2023
 
 #### Fixed
-- Gracefully handle decrypting an unencrypted method. If decryption error occurs when trying to decrypt a plain text the plain text message will be returned and error field will be set in the response. This works both for history and subscription messages.
+- Gracefully handle decrypting an unencrypted method. If a decryption error occurs when trying to decrypt plain text, the plain text message will be returned and an error field will be set in the response. This works for both history and subscription messages.
 
 ## v6.1.2
 November 02 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v6.1.3
+November 27 2023
+
+#### Fixed
+- Gracefully handle decrypting an unencrypted method. If decryption error occurs when trying to decrypt a plain text the plain text message will be returned and error field will be set in the response. This works both for history and subscription messages.
+
 ## v6.1.2
 November 02 2023
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
          {
              "require": {
                  <!-- include the latest version from the badge at the top -->
-                 "pubnub/pubnub": "6.1.2"
+                 "pubnub/pubnub": "6.1.3"
              }
          }
          ```

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "keywords": ["api", "real-time", "realtime", "real time", "ajax", "push"],
   "homepage": "http://www.pubnub.com/",
   "license": "proprietary",
+  "version": "6.1.2",
   "authors": [
     {
       "name": "PubNub",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["api", "real-time", "realtime", "real time", "ajax", "push"],
   "homepage": "http://www.pubnub.com/",
   "license": "proprietary",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "authors": [
     {
       "name": "PubNub",

--- a/examples/cli/hist.php
+++ b/examples/cli/hist.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+set_time_limit(0);
+
+require('../../vendor/autoload.php');
+
+use PubNub\PubNub;
+use PubNub\PNConfiguration;
+use PubNub\CryptoModule;
+
+$pnUuid = 'pn-610da4553bb079.92567429'; //uniqid('pn-', true);
+
+$pnConfig = new PNConfiguration();
+$pnConfig->setPublishKey(getenv('PN_KEY_PUBLISH'));
+$pnConfig->setSubscribeKey(getenv('PN_KEY_SUBSCRIBE'));
+// $pnConfig->setSecretKey('sec-c-YjZiZWQzZWItMmZlNS00NjBlLTkyNTUtOGFhZjZiY2E1ZDc1');
+$pnConfig->setUuid($pnUuid);
+if (array_key_exists(2, $argv)) {
+    $pnConfig->setCrypto(CryptoModule::aesCbcCryptor($argv[2], true));
+}
+
+$pubnub = new PubNub($pnConfig);
+
+$ts = $pubnub->time()->sync();
+
+$channelName = $argv[1];
+$history = $pubnub->history()
+    ->channel($channelName)
+    ->reverse(false)
+    ->end((int)($ts->getTimetoken() - 3000000000))
+    ->count(50)
+    ->sync();
+
+foreach ($history->getMessages() as $key => $message) {
+    print($message);
+}

--- a/examples/cli/pub.php
+++ b/examples/cli/pub.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+set_time_limit(0);
+
+require('../../vendor/autoload.php');
+
+
+use PubNub\PubNub;
+use PubNub\PNConfiguration;
+use PubNub\CryptoModule;
+
+$pnUuid = $argv[1] . '-pn-610da4553bb079.92567429';
+
+$pnConfig = new PNConfiguration();
+$pnConfig->setPublishKey(getenv('PN_KEY_PUBLISH'));
+$pnConfig->setSubscribeKey(getenv('PN_KEY_SUBSCRIBE'));
+$pnConfig->setUuid($pnUuid);
+if (array_key_exists(4, $argv)) {
+    $pnConfig->setCrypto(CryptoModule::aesCbcCryptor($argv[4], true));
+}
+
+$pubnub = new PubNub($pnConfig);
+
+$pubResult = $pubnub->publish()->channel($argv[2])->message($argv[3])->sync();

--- a/examples/cli/sub.php
+++ b/examples/cli/sub.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED);
+
+set_time_limit(0);
+
+require('../../vendor/autoload.php');
+
+use PubNub\Callbacks\SubscribeCallback;
+use PubNub\Exceptions\PubNubException;
+use PubNub\Models\Consumer\PubSub\PNMessageResult;
+use PubNub\Models\Consumer\PubSub\PNPresenceEventResult;
+use PubNub\Models\ResponseHelpers\PNStatus;
+use PubNub\PubNub;
+use PubNub\PNConfiguration;
+use PubNub\CryptoModule;
+
+
+$pnUuid = 'pn-610da4553bb079.92567429';
+
+$pnConfig = new PNConfiguration();
+$pnConfig->setPublishKey(getenv('PN_KEY_PUBLISH'));
+$pnConfig->setSubscribeKey(getenv('PN_KEY_SUBSCRIBE'));
+if (array_key_exists(2, $argv)) {
+    $pnConfig->setCrypto(CryptoModule::aesCbcCryptor($argv[2], true));
+}
+$pnConfig->setUuid($pnUuid);
+
+$pubnub = new PubNub($pnConfig);
+
+$channelName = $argv[1];
+
+// phpcs:ignore
+class MySubscribeCallback extends SubscribeCallback
+{
+    /**
+     * @param PubNub $pubnub
+     * @param PNStatus $status
+     * @return void
+     * @throws PubNubException
+     */
+    public function status($pubnub, $status)
+    {
+        printf(
+            "Category: %s\nPublisher user_id: %s",
+            $status->getCategory(),
+            $status->getUuid()
+        );
+    }
+
+    /**
+     * @param PubNub $pubnub
+     * @param PNMessageResult $messageResult
+     * @return void
+     */
+    public function message($pubnub, $messageResult)
+    {
+        printf(
+            "\nMessage %s\n Channel: %s\n Timetoken: %s\n Publisher: %s\n",
+            $messageResult->getMessage(),
+            $messageResult->getChannel(),
+            $messageResult->getTimetoken(),
+            $messageResult->getPublisher(),
+        );
+        if ($messageResult->isError()) {
+            printf('\nError occured during parsing the message: %s', $messageResult->getError()->getMessage());
+        }
+    }
+
+    /**
+     * @param PubNub $pubnub
+     * @param PNPresenceEventResult $presence
+     * @return void
+     */
+    public function presence($pubnub, $presence)
+    {
+        print("{$presence->getEvent()}: {$presence->getUuid()}");
+    }
+
+    /**
+     * @param PubNub $pubnub
+     * @param PNSignalMessageResult $signal
+     * @return void
+     */
+    public function signal($pubnub, $signal)
+    {
+    }
+}
+
+$subscribeCallback = new MySubscribeCallback();
+
+$pubnub->addListener($subscribeCallback);
+
+echo "subscribing to: $channelName\n";
+
+$subResult = $pubnub->subscribe()
+    ->channels($channelName)
+    ->withTimetoken(true)
+    ->withPresence(true)
+    ->execute();
+
+echo "done.\n";

--- a/src/PubNub/Models/Consumer/History/PNHistoryItemResult.php
+++ b/src/PubNub/Models/Consumer/History/PNHistoryItemResult.php
@@ -4,7 +4,6 @@ namespace PubNub\Models\Consumer\History;
 
 use PubNub\PubNubCryptoCore;
 
-
 class PNHistoryItemResult
 {
     /** @var  any */
@@ -15,6 +14,8 @@ class PNHistoryItemResult
 
     /** @var  int */
     private $timetoken;
+
+    private $error = null;
 
     /**
      * PNHistoryItemResult constructor.
@@ -36,10 +37,14 @@ class PNHistoryItemResult
 
     public function decrypt()
     {
-        if (is_string($this->entry)) {
-            $this->entry = $this->crypto->decrypt($this->entry);
-        } elseif (is_array($this->entry) and key_exists('pn_other', $this->entry)) {
-            $this->entry['pn_other'] = $this->crypto->decrypt($this->entry['pn_other']);
+        try {
+            if (is_string($this->entry)) {
+                $this->entry = $this->crypto->decrypt($this->entry);
+            } elseif (is_array($this->entry) and key_exists('pn_other', $this->entry)) {
+                $this->entry['pn_other'] = $this->crypto->decrypt($this->entry['pn_other']);
+            }
+        } catch (\Exception $error) {
+            $this->error = $error;
         }
     }
 

--- a/src/PubNub/Models/Consumer/PubSub/PNMessageResult.php
+++ b/src/PubNub/Models/Consumer/PubSub/PNMessageResult.php
@@ -2,7 +2,6 @@
 
 namespace PubNub\Models\Consumer\PubSub;
 
-
 class PNMessageResult
 {
     /** @var  array */
@@ -20,6 +19,8 @@ class PNMessageResult
     /** @var  string */
     private $publisher;
 
+    private $error;
+
     /**
      * PNMessageResult constructor.
      * @param array $message
@@ -28,13 +29,14 @@ class PNMessageResult
      * @param int $timetoken
      * @param string $publisher
      */
-    public function __construct($message, $channel, $subscription, $timetoken, $publisher)
+    public function __construct($message, $channel, $subscription, $timetoken, $publisher, $error = null)
     {
         $this->message = $message;
         $this->channel = $channel;
         $this->subscription = $subscription;
         $this->timetoken = $timetoken;
         $this->publisher = $publisher;
+        $this->error = $error;
     }
 
     /**
@@ -75,5 +77,15 @@ class PNMessageResult
     public function getPublisher()
     {
         return $this->publisher;
+    }
+
+    public function isError(): bool
+    {
+        return !is_null($this->error);
+    }
+
+    public function getError()
+    {
+        return $this->error;
     }
 }

--- a/src/PubNub/PubNub.php
+++ b/src/PubNub/PubNub.php
@@ -53,7 +53,7 @@ use Psr\Log\NullLogger;
 
 class PubNub implements LoggerAwareInterface
 {
-    protected const SDK_VERSION = "6.1.2";
+    protected const SDK_VERSION = "6.1.3";
     protected const SDK_NAME = "PubNub-PHP";
 
     public static $MAX_SEQUENCE = 65535;


### PR DESCRIPTION
fix: Gracefully handle decrypting an unencrypted method. If a decryption error occurs when trying to decrypt plain text, the plain text message will be returned and an error field will be set in the response. This works for both history and subscription messages.