### PR TITLE
GCM to FCM migration

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: php
-version: 6.1.3
+version: 6.2.0
 schema: 1
 scm: github.com/pubnub/php
 changelog:
+  - date: 2024-06-11
+    version: v6.2.0
+    changes:
+      - type: feature
+        text: "Replacing GCM with FCM. This is not a breaking change, but using GCM will result in throwing `E_USER_DEPRECATED` warning."
   - date: 2023-11-27
     version: v6.1.3
     changes:
@@ -407,8 +412,8 @@ sdks:
                     - x86-64
           - distribution-type: library
             distribution-repository: GitHub release
-            package-name: php-6.1.3.zip
-            location: https://github.com/pubnub/php/releases/tag/v6.1.3
+            package-name: php-6.2.0.zip
+            location: https://github.com/pubnub/php/releases/tag/v6.2.0
             requires:
               - name: rmccue/requests
                 min-version: 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v6.2.0
+June 11 2024
+
+#### Added
+- Replacing GCM with FCM. This is not a breaking change, but using GCM will result in throwing `E_USER_DEPRECATED` warning.
+
 ## v6.1.3
 November 27 2023
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
          {
              "require": {
                  <!-- include the latest version from the badge at the top -->
-                 "pubnub/pubnub": "6.1.3"
+                 "pubnub/pubnub": "6.2.0"
              }
          }
          ```

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["api", "real-time", "realtime", "real time", "ajax", "push"],
   "homepage": "http://www.pubnub.com/",
   "license": "proprietary",
-  "version": "6.1.3",
+  "version": "6.2.0",
   "authors": [
     {
       "name": "PubNub",

--- a/src/PubNub/Endpoints/Push/AddChannelsToPush.php
+++ b/src/PubNub/Endpoints/Push/AddChannelsToPush.php
@@ -2,109 +2,39 @@
 
 namespace PubNub\Endpoints\Push;
 
-use PubNub\Endpoints\Endpoint;
-use PubNub\Enums\PNHttpMethod;
 use PubNub\Enums\PNOperationType;
 use PubNub\Enums\PNPushType;
 use PubNub\Exceptions\PubNubValidationException;
 use PubNub\Models\Consumer\Push\PNPushAddChannelResult;
 use PubNub\PubNubUtil;
 
-
-class AddChannelsToPush extends Endpoint
+class AddChannelsToPush extends PushEndpoint
 {
-    const PATH = "/v1/push/sub-key/%s/devices/%s";
-
-    const PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s";
+    protected const OPERATION_TYPE = PNOperationType::PNAddPushNotificationsOnChannelsOperation;
+    protected const OPERATION_NAME = "AddChannelsToPush";
+    public const PATH = "/v1/push/sub-key/%s/devices/%s";
+    public const PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s";
 
     /** @var  string[]|string */
-    protected $channels = [];
-
-    /** @var  string */
-    protected $deviceId;
-
-    /** @var  int */
-    protected $pushType;
-
-    /** @var  string */
-    protected $environment;
-
-    /** @var  string */
-    protected $topic;
+    protected string | array $channels = [];
 
     /**
      * @param string[]|string $channels
      * @return $this
      */
-    public function channels($channels)
+    public function channels(string | array $channels)
     {
         $this->channels = PubNubUtil::extendArray($this->channels, $channels);
 
         return $this;
     }
 
-    /**
-     * @param string $deviceId
-     * @return $this
-     */
-    public function deviceId($deviceId)
-    {
-        $this->deviceId = $deviceId;
-
-        return $this;
-    }
-
-    /**
-     * @param int $pushType
-     * @return $this
-     */
-    public function pushType($pushType)
-    {
-        $this->pushType = $pushType;
-
-        return $this;
-    }
-
-    /**
-     * @param int $environment
-     * @return $this
-     */
-    public function environment($environment)
-    {
-        $this->environment = $environment;
-
-        return $this;
-    }
-
-    /**
-     * @param int $pushType
-     * @return $this
-     */
-    public function topic($topic)
-    {
-        $this->topic = $topic;
-
-        return $this;
-    }
-
     protected function validateParams()
     {
-        $this->validateSubscribeKey();
+        parent::validateParams();
 
         if (!is_array($this->channels) || count($this->channels) === 0) {
             throw new PubNubValidationException("Channel missing");
-        }
-
-        if (!is_string($this->deviceId) || strlen($this->deviceId) === 0) {
-            throw new PubNubValidationException("Device ID is missing for push operation");
-        }
-
-        if ($this->pushType === null || strlen($this->pushType) === 0) {
-            throw new PubNubValidationException("Push Type is missing");
-        }
-
-        if (($this->pushType == PNPushType::APNS2) && (!is_string($this->topic) || strlen($this->topic) === 0)) {
-            throw new PubNubValidationException("APNS2 topic is missing");
         }
     }
 
@@ -163,53 +93,5 @@ class AddChannelsToPush extends Endpoint
     protected function createResponse($json)
     {
         return new PNPushAddChannelResult();
-    }
-
-    /**
-     * @return bool
-     */
-    protected function isAuthRequired()
-    {
-        return true;
-    }
-
-    /**
-     * @return int
-     */
-    protected function getRequestTimeout()
-    {
-        return $this->pubnub->getConfiguration()->getNonSubscribeRequestTimeout();
-    }
-
-    /**
-     * @return int
-     */
-    protected function getConnectTimeout()
-    {
-        return $this->pubnub->getConfiguration()->getConnectTimeout();
-    }
-
-    /**
-     * @return string PNHttpMethod
-     */
-    protected function httpMethod()
-    {
-        return PNHttpMethod::GET;
-    }
-
-    /**
-     * @return int
-     */
-    protected function getOperationType()
-    {
-        return PNOperationType::PNAddPushNotificationsOnChannelsOperation;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getName()
-    {
-        return "AddChannelsToPush";
     }
 }

--- a/src/PubNub/Endpoints/Push/ListPushProvisions.php
+++ b/src/PubNub/Endpoints/Push/ListPushProvisions.php
@@ -2,95 +2,18 @@
 
 namespace PubNub\Endpoints\Push;
 
-use PubNub\Endpoints\Endpoint;
 use PubNub\Enums\PNHttpMethod;
 use PubNub\Enums\PNOperationType;
 use PubNub\Enums\PNPushType;
 use PubNub\Exceptions\PubNubValidationException;
 use PubNub\Models\Consumer\Push\PNPushListProvisionsResult;
 
-
-class ListPushProvisions extends Endpoint
+class ListPushProvisions extends PushEndpoint
 {
-    const PATH = "/v1/push/sub-key/%s/devices/%s";
-
-    const PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s";
-
-    /** @var  string */
-    protected $deviceId;
-
-    /** @var  int */
-    protected $pushType;
-
-    /** @var  string */
-    protected $environment;
-
-    /** @var  string */
-    protected $topic;
-
-    /**
-     * @param string $deviceId
-     * @return $this
-     */
-    public  function deviceId($deviceId)
-    {
-        $this->deviceId = $deviceId;
-
-        return $this;
-    }
-
-    /**
-     * @param int $pushType
-     * @return $this
-     */
-    public function pushType($pushType)
-    {
-        $this->pushType = $pushType;
-
-        return $this;
-    }
-
-    /**
-     * @param int $environment
-     * @return $this
-     */
-    public function environment($environment)
-    {
-        $this->environment = $environment;
-
-        return $this;
-    }
-
-    /**
-     * @param int $pushType
-     * @return $this
-     */
-    public function topic($topic)
-    {
-        $this->topic = $topic;
-
-        return $this;
-    }
-
-    /**
-     * @throws PubNubValidationException
-     */
-    protected function validateParams()
-    {
-        $this->validateSubscribeKey();
-
-        if (!is_string($this->deviceId) || strlen($this->deviceId) === 0) {
-            throw new PubNubValidationException("Device ID is missing for push operation");
-        }
-
-        if ($this->pushType === null || strlen($this->pushType) === 0) {
-            throw new PubNubValidationException("Push Type is missing");
-        }
-
-        if (($this->pushType == PNPushType::APNS2) && (!is_string($this->topic) || strlen($this->topic) === 0)) {
-            throw new PubNubValidationException("APNS2 topic is missing");
-        }
-    }
+    protected const OPERATION_TYPE = PNOperationType::PNPushNotificationEnabledChannelsOperation;
+    protected const OPERATION_NAME = "ListPushProvisions";
+    public const PATH = "/v1/push/sub-key/%s/devices/%s";
+    public const PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s";
 
     /**
      * @return array
@@ -149,53 +72,5 @@ class ListPushProvisions extends Endpoint
         } else {
             return new PNPushListProvisionsResult([]);
         }
-    }
-
-    /**
-     * @return bool
-     */
-    protected function isAuthRequired()
-    {
-        return true;
-    }
-
-    /**
-     * @return int
-     */
-    protected function getRequestTimeout()
-    {
-        return $this->pubnub->getConfiguration()->getNonSubscribeRequestTimeout();
-    }
-
-    /**
-     * @return int
-     */
-    protected function getConnectTimeout()
-    {
-        return $this->pubnub->getConfiguration()->getConnectTimeout();
-    }
-
-    /**
-     * @return string PNHttpMethod
-     */
-    protected function httpMethod()
-    {
-        return PNHttpMethod::GET;
-    }
-
-    /**
-     * @return int
-     */
-    protected function getOperationType()
-    {
-        return PNOperationType::PNPushNotificationEnabledChannelsOperation;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getName()
-    {
-        return "ListPushProvisions";
     }
 }

--- a/src/PubNub/Endpoints/Push/PushEndpoint.php
+++ b/src/PubNub/Endpoints/Push/PushEndpoint.php
@@ -58,20 +58,15 @@ abstract class PushEndpoint extends Endpoint
 
     protected function validatePushType()
     {
-        if (!isset($this->pushType) || $this->pushType === null || strlen($this->pushType) === 0) {
-            throw new PubNubValidationException("Push type missing");
+        if (!isset($this->pushType) || empty($this->pushType)) {
+            throw new PubNubValidationException("Push Type is missing");
         }
 
         if ($this->pushType === PNPushType::GCM) {
             trigger_error("GCM is deprecated. Please use FCM instead.", E_USER_DEPRECATED);
         }
 
-        if (
-            !in_array(
-                $this->pushType,
-                [PNPushType::APNS, PNPushType::APNS2, PNPushType::MPNS, PNPushType::GCM, PNPushType::FCM]
-            )
-        ) {
+        if (!in_array($this->pushType, PNPushType::all())) {
             throw new PubNubValidationException("Invalid push type");
         }
     }
@@ -81,14 +76,14 @@ abstract class PushEndpoint extends Endpoint
      */
     protected function validateDeviceId()
     {
-        if (!is_string($this->deviceId) || strlen($this->deviceId) === 0) {
+        if (!isset($this->deviceId) || empty($this->deviceId)) {
             throw new PubNubValidationException("Device ID is missing for push operation");
         }
     }
 
     protected function validateTopic()
     {
-        if (($this->pushType == PNPushType::APNS2) && (!is_string($this->topic) || strlen($this->topic) === 0)) {
+        if (($this->pushType == PNPushType::APNS2) && (!isset($this->topic) || empty($this->topic))) {
             throw new PubNubValidationException("APNS2 topic is missing");
         }
     }

--- a/src/PubNub/Endpoints/Push/PushEndpoint.php
+++ b/src/PubNub/Endpoints/Push/PushEndpoint.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace PubNub\Endpoints\Push;
+
+use PubNub\Endpoints\Endpoint;
+use PubNub\Enums\PNHttpMethod;
+use PubNub\Enums\PNOperationType;
+use PubNub\Enums\PNPushType;
+use PubNub\Exceptions\PubNubValidationException;
+
+abstract class PushEndpoint extends Endpoint
+{
+    protected const OPERATION_TYPE = null;
+    protected const OPERATION_NAME = null;
+    protected string $deviceId;
+    protected string $pushType;
+    protected string $environment;
+    protected string $topic;
+
+    /**
+     * @param string $deviceId
+     * @return $this
+     */
+    public function deviceId(string $deviceId): static
+    {
+        $this->deviceId = $deviceId;
+        return $this;
+    }
+
+    /**
+     * @param string $environment
+     * @return $this
+     */
+    public function environment(string $environment): static
+    {
+        $this->environment = $environment;
+        return $this;
+    }
+
+    /**
+     * @param string  $topic
+     * @return $this
+     */
+    public function topic(string $topic): static
+    {
+        $this->topic = $topic;
+        return $this;
+    }
+
+    /**
+     * @param string $pushType
+     * @return $this
+     */
+    public function pushType(string $pushType): static
+    {
+        $this->pushType = $pushType;
+        return $this;
+    }
+
+    protected function validatePushType()
+    {
+        if ($this->pushType === null || strlen($this->pushType) === 0) {
+            throw new PubNubValidationException("Push type missing");
+        }
+
+        if ($this->pushType === PNPushType::GCM) {
+            trigger_error("GCM is deprecated. Please use FCM instead.", E_USER_DEPRECATED);
+        }
+
+        if (
+            !in_array(
+                $this->pushType,
+                [PNPushType::APNS, PNPushType::APNS2, PNPushType::MPNS, PNPushType::GCM, PNPushType::FCM]
+            )
+        ) {
+            throw new PubNubValidationException("Invalid push type");
+        }
+    }
+
+    /**
+     * @throws PubNubValidationException
+     */
+    protected function validateDeviceId()
+    {
+        if (!is_string($this->deviceId) || strlen($this->deviceId) === 0) {
+            throw new PubNubValidationException("Device ID is missing for push operation");
+        }
+    }
+
+    protected function validateTopic()
+    {
+        if (($this->pushType == PNPushType::APNS2) && (!is_string($this->topic) || strlen($this->topic) === 0)) {
+            throw new PubNubValidationException("APNS2 topic is missing");
+        }
+    }
+
+     /**
+     * @throws PubNubValidationException
+     */
+    protected function validateParams()
+    {
+        $this->validateSubscribeKey();
+        $this->validateDeviceId();
+        $this->validatePushType();
+        $this->validateTopic();
+    }
+
+     /**
+     * @return bool
+     */
+    protected function isAuthRequired()
+    {
+        return true;
+    }
+
+    /**
+     * @return int
+     */
+    protected function getRequestTimeout()
+    {
+        return $this->pubnub->getConfiguration()->getNonSubscribeRequestTimeout();
+    }
+
+    /**
+     * @return int
+     */
+    protected function getConnectTimeout()
+    {
+        return $this->pubnub->getConfiguration()->getConnectTimeout();
+    }
+
+    /**
+     * @return string PNHttpMethod
+     */
+    protected function httpMethod()
+    {
+        return PNHttpMethod::GET;
+    }
+
+    /**
+     * @return int
+     */
+    protected function getOperationType()
+    {
+        return static::OPERATION_TYPE;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getName()
+    {
+        return static::OPERATION_NAME;
+    }
+}

--- a/src/PubNub/Endpoints/Push/PushEndpoint.php
+++ b/src/PubNub/Endpoints/Push/PushEndpoint.php
@@ -4,7 +4,6 @@ namespace PubNub\Endpoints\Push;
 
 use PubNub\Endpoints\Endpoint;
 use PubNub\Enums\PNHttpMethod;
-use PubNub\Enums\PNOperationType;
 use PubNub\Enums\PNPushType;
 use PubNub\Exceptions\PubNubValidationException;
 
@@ -14,7 +13,7 @@ abstract class PushEndpoint extends Endpoint
     protected const OPERATION_NAME = null;
     protected string $deviceId;
     protected string $pushType;
-    protected string $environment;
+    protected string $environment = 'development';
     protected string $topic;
 
     /**
@@ -59,7 +58,7 @@ abstract class PushEndpoint extends Endpoint
 
     protected function validatePushType()
     {
-        if ($this->pushType === null || strlen($this->pushType) === 0) {
+        if (!isset($this->pushType) || $this->pushType === null || strlen($this->pushType) === 0) {
             throw new PubNubValidationException("Push type missing");
         }
 

--- a/src/PubNub/Endpoints/Push/RemoveChannelsFromPush.php
+++ b/src/PubNub/Endpoints/Push/RemoveChannelsFromPush.php
@@ -2,88 +2,29 @@
 
 namespace PubNub\Endpoints\Push;
 
-use PubNub\Endpoints\Endpoint;
-use PubNub\Enums\PNHttpMethod;
 use PubNub\Enums\PNOperationType;
 use PubNub\Enums\PNPushType;
 use PubNub\Exceptions\PubNubValidationException;
 use PubNub\Models\Consumer\Push\PNPushRemoveChannelResult;
 use PubNub\PubNubUtil;
 
-
-class RemoveChannelsFromPush extends Endpoint
+class RemoveChannelsFromPush extends PushEndpoint
 {
-    const PATH = "/v1/push/sub-key/%s/devices/%s";
+    protected const OPERATION_TYPE = PNOperationType::PNRemovePushNotificationsFromChannelsOperation;
+    protected const OPERATION_NAME = "RemoveChannelsFromPush";
+    public const PATH = "/v1/push/sub-key/%s/devices/%s";
+    public const PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s";
 
-    const PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s";
-
-    /** @var  string[] */
-    protected $channels = [];
-
-    /** @var  string */
-    protected $deviceId;
-
-    /** @var  string */
-    protected $pushType;
-
-    /** @var  string */
-    protected $environment;
-
-    /** @var  string */
-    protected $topic;
+    /** @var  string | string[] */
+    protected string | array $channels = [];
 
     /**
      * @param string|string[] $channels
      * @return $this
      */
-    public function channels($channels)
+    public function channels(string | array $channels): static
     {
         $this->channels = PubNubUtil::extendArray($this->channels, $channels);
-
-        return $this;
-    }
-
-    /**
-     * @param string $deviceId
-     * @return $this
-     */
-    public function deviceId($deviceId)
-    {
-        $this->deviceId = $deviceId;
-
-        return $this;
-    }
-
-    /**
-     * @param int $pushType
-     * @return $this
-     */
-    public function pushType($pushType)
-    {
-        $this->pushType = $pushType;
-
-        return $this;
-    }
-
-    /**
-     * @param int $environment
-     * @return $this
-     */
-    public function environment($environment)
-    {
-        $this->environment = $environment;
-
-        return $this;
-    }
-
-    /**
-     * @param int $pushType
-     * @return $this
-     */
-    public function topic($topic)
-    {
-        $this->topic = $topic;
-
         return $this;
     }
 
@@ -133,7 +74,6 @@ class RemoveChannelsFromPush extends Endpoint
                 $params['environment'] = 'development';
             }
         }
-
         return $params;
     }
 
@@ -150,7 +90,7 @@ class RemoveChannelsFromPush extends Endpoint
      */
     protected function buildPath()
     {
-        $path = $this->pushType == PNPushType::APNS2 ? RemoveChannelsFromPush::PATH_APNS2 : RemoveChannelsFromPush::PATH;
+        $path = $this->pushType == PNPushType::APNS2 ? static::PATH_APNS2 : static::PATH;
 
         return sprintf(
             $path,
@@ -166,53 +106,5 @@ class RemoveChannelsFromPush extends Endpoint
     protected function createResponse($json)
     {
         return new PNPushRemoveChannelResult();
-    }
-
-    /**
-     * @return bool
-     */
-    protected function isAuthRequired()
-    {
-        return true;
-    }
-
-    /**
-     * @return int
-     */
-    protected function getRequestTimeout()
-    {
-        return $this->pubnub->getConfiguration()->getNonSubscribeRequestTimeout();
-    }
-
-    /**
-     * @return int
-     */
-    protected function getConnectTimeout()
-    {
-        return $this->pubnub->getConfiguration()->getConnectTimeout();
-    }
-
-    /**
-     * @return string PNHttpMethod
-     */
-    protected function httpMethod()
-    {
-        return PNHttpMethod::GET;
-    }
-
-    /**
-     * @return int
-     */
-    protected function getOperationType()
-    {
-        return PNOperationType::PNRemovePushNotificationsFromChannelsOperation;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getName()
-    {
-        return "RemoveChannelsFromPush";
     }
 }

--- a/src/PubNub/Endpoints/Push/RemoveChannelsFromPush.php
+++ b/src/PubNub/Endpoints/Push/RemoveChannelsFromPush.php
@@ -34,21 +34,16 @@ class RemoveChannelsFromPush extends PushEndpoint
     protected function validateParams()
     {
         $this->validateSubscribeKey();
+        $this->validateChannel();
+        $this->validateDeviceId();
+        $this->validatePushType();
+        $this->validateTopic();
+    }
 
+    protected function validateChannel()
+    {
         if (!is_array($this->channels) || count($this->channels) === 0) {
             throw new PubNubValidationException("Channel missing");
-        }
-
-        if (!is_string($this->deviceId) || strlen($this->deviceId) === 0) {
-            throw new PubNubValidationException("Device ID is missing for push operation");
-        }
-
-        if ($this->pushType === null || strlen($this->pushType) === 0) {
-            throw new PubNubValidationException("Push Type is missing");
-        }
-
-        if (($this->pushType == PNPushType::APNS2) && (!is_string($this->topic) || strlen($this->topic) === 0)) {
-            throw new PubNubValidationException("APNS2 topic is missing");
         }
     }
 

--- a/src/PubNub/Endpoints/Push/RemoveChannelsFromPush.php
+++ b/src/PubNub/Endpoints/Push/RemoveChannelsFromPush.php
@@ -67,12 +67,7 @@ class RemoveChannelsFromPush extends PushEndpoint
         } else {
             // apns2 push -> add topic and environment
             $params['topic'] = $this->topic;
-
-            if (is_string($this->environment) && strlen($this->environment) > 0) {
-                $params['environment'] = $this->environment;
-            } else {
-                $params['environment'] = 'development';
-            }
+            $params['environment'] = $this->environment ?? 'development';
         }
         return $params;
     }

--- a/src/PubNub/Endpoints/Push/RemoveDeviceFromPush.php
+++ b/src/PubNub/Endpoints/Push/RemoveDeviceFromPush.php
@@ -9,88 +9,12 @@ use PubNub\Enums\PNPushType;
 use PubNub\Exceptions\PubNubValidationException;
 use PubNub\Models\Consumer\Push\PNPushRemoveAllChannelsResult;
 
-
-class RemoveDeviceFromPush extends Endpoint
+class RemoveDeviceFromPush extends PushEndpoint
 {
-    const PATH = "/v1/push/sub-key/%s/devices/%s/remove";
-
-    const PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s/remove";
-
-    /** @var  string */
-    protected $deviceId;
-
-    /** @var  string */
-    protected $pushType;
-
-    /** @var  string */
-    protected $environment;
-
-    /** @var  string */
-    protected $topic;
-
-    /**
-     * @param string $deviceId
-     * @return $this
-     */
-    public function deviceId($deviceId)
-    {
-        $this->deviceId = $deviceId;
-
-        return $this;
-    }
-
-    /**
-     * @param int $pushType
-     * @return $this
-     */
-    public function pushType($pushType)
-    {
-        $this->pushType = $pushType;
-
-        return $this;
-    }
-
-    /**
-     * @param int $environment
-     * @return $this
-     */
-    public function environment($environment)
-    {
-        $this->environment = $environment;
-
-        return $this;
-    }
-
-    /**
-     * @param int $pushType
-     * @return $this
-     */
-    public function topic($topic)
-    {
-        $this->topic = $topic;
-
-        return $this;
-    }
-
-    /**
-     * @throws PubNubValidationException
-     */
-    protected function validateParams()
-    {
-        $this->validateSubscribeKey();
-
-        if (!is_string($this->deviceId) || strlen($this->deviceId) === 0) {
-            throw new PubNubValidationException("Device ID is missing for push operation");
-        }
-
-        if ($this->pushType === null || strlen($this->pushType) === 0) {
-            throw new PubNubValidationException("Push Type is missing");
-        }
-
-        if (($this->pushType == PNPushType::APNS2) && (!is_string($this->topic) || strlen($this->topic) === 0)) {
-            throw new PubNubValidationException("APNS2 topic is missing");
-        }
-    }
+    protected const OPERATION_TYPE = PNOperationType::PNRemoveAllPushNotificationsOperation;
+    protected const OPERATION_NAME = "RemoveDeviceFromPush";
+    public const PATH = "/v1/push/sub-key/%s/devices/%s/remove";
+    public const PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s/remove";
 
     /**
      * @return array
@@ -145,53 +69,5 @@ class RemoveDeviceFromPush extends Endpoint
     protected function createResponse($json)
     {
         return new PNPushRemoveAllChannelsResult();
-    }
-
-    /**
-     * @return bool
-     */
-    protected function isAuthRequired()
-    {
-        return true;
-    }
-
-    /**
-     * @return int
-     */
-    protected function getRequestTimeout()
-    {
-        return $this->pubnub->getConfiguration()->getNonSubscribeRequestTimeout();
-    }
-
-    /**
-     * @return int
-     */
-    protected function getConnectTimeout()
-    {
-        return $this->pubnub->getConfiguration()->getConnectTimeout();
-    }
-
-    /**
-     * @return string PNHttpMethod
-     */
-    protected function httpMethod()
-    {
-        return PNHttpMethod::GET;
-    }
-
-    /**
-     * @return int
-     */
-    protected function getOperationType()
-    {
-        return PNOperationType::PNRemoveAllPushNotificationsOperation;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getName()
-    {
-        return "RemoveDeviceFromPush";
     }
 }

--- a/src/PubNub/Enums/PNPushType.php
+++ b/src/PubNub/Enums/PNPushType.php
@@ -2,11 +2,11 @@
 
 namespace PubNub\Enums;
 
-
 class PNPushType
 {
-    const APNS = "apns";
-    const APNS2 = "apns2";
-    const MPNS = "mpns";
-    const GCM = "gcm";
+    public const APNS = "apns";
+    public const APNS2 = "apns2";
+    public const MPNS = "mpns";
+    public const GCM = "gcm";
+    public const FCM = "fcm";
 }

--- a/src/PubNub/Enums/PNPushType.php
+++ b/src/PubNub/Enums/PNPushType.php
@@ -9,4 +9,15 @@ class PNPushType
     public const MPNS = "mpns";
     public const GCM = "gcm";
     public const FCM = "fcm";
+
+    public static function all()
+    {
+        return [
+            self::APNS,
+            self::APNS2,
+            self::MPNS,
+            self::GCM,
+            self::FCM
+        ];
+    }
 }

--- a/src/PubNub/PubNub.php
+++ b/src/PubNub/PubNub.php
@@ -55,7 +55,7 @@ use Psr\Log\NullLogger;
 
 class PubNub implements LoggerAwareInterface
 {
-    protected const SDK_VERSION = "6.1.3";
+    protected const SDK_VERSION = "6.2.0";
     protected const SDK_NAME = "PubNub-PHP";
 
     public static $MAX_SEQUENCE = 65535;

--- a/tests/functional/push/AddChannelsToPushTest.php
+++ b/tests/functional/push/AddChannelsToPushTest.php
@@ -8,7 +8,6 @@ use PubNub\PubNub;
 use PubNub\PubNubUtil;
 use PubNubTestCase;
 
-
 class AddChannelsToPushTest extends PubNubTestCase
 {
     public function testPushAddSingleChannel()
@@ -92,14 +91,14 @@ class AddChannelsToPushTest extends PubNubTestCase
         $this->assertEquals(["ch1","ch2"], $add->getChannels());
     }
 
-    public function testPushAddGoogle()
+    public function testPushAddFCM()
     {
         $this->pubnub->getConfiguration()->setUuid("sampleUUID");
 
         $add = new AddChannelsToPushExposed($this->pubnub);
 
         $add->channels(["ch1", "ch2", "ch3"])
-            ->pushType(PNPushType::GCM)
+            ->pushType(PNPushType::FCM)
             ->deviceId("coolDevice");
 
         $this->assertEquals(sprintf(
@@ -111,7 +110,7 @@ class AddChannelsToPushTest extends PubNubTestCase
         $this->assertEquals([
             "pnsdk" => PubNubUtil::urlEncode(PubNub::getSdkFullName()),
             "uuid" => $this->pubnub->getConfiguration()->getUuid(),
-            "type" => "gcm",
+            "type" => "fcm",
             "add" => "ch1,ch2,ch3"
         ], $add->buildParams());
 
@@ -119,7 +118,7 @@ class AddChannelsToPushTest extends PubNubTestCase
     }
 }
 
-
+// phpcs:ignore PSR1.Classes.ClassDeclaration
 class AddChannelsToPushExposed extends AddChannelsToPush
 {
     public function buildParams()

--- a/tests/functional/push/ListPushProvisionsTest.php
+++ b/tests/functional/push/ListPushProvisionsTest.php
@@ -9,7 +9,6 @@ use PubNub\PubNubUtil;
 use PubNubTestCase;
 use Tests\Helpers\StubTransport;
 
-
 class ListPushProvisionsTest extends PubNubTestCase
 {
     public function testListChannelGroupAPNS()
@@ -59,13 +58,13 @@ class ListPushProvisionsTest extends PubNubTestCase
         ], $list->buildParams());
     }
 
-    public function testListChannelGroupGCM()
+    public function testListChannelGroupFCM()
     {
         $this->pubnub->getConfiguration()->setUuid("sampleUUID");
 
         $list = new ListPushProvisionsExposed($this->pubnub);
 
-        $list->pushType(PNPushType::GCM)
+        $list->pushType(PNPushType::FCM)
             ->deviceId("coolDevice");
 
         $this->assertEquals(sprintf(
@@ -77,7 +76,7 @@ class ListPushProvisionsTest extends PubNubTestCase
         $this->assertEquals([
             "pnsdk" => PubNubUtil::urlEncode(PubNub::getSdkFullName()),
             "uuid" => $this->pubnub->getConfiguration()->getUuid(),
-            "type" => "gcm"
+            "type" => "fcm"
         ], $list->buildParams());
     }
 
@@ -104,7 +103,7 @@ class ListPushProvisionsTest extends PubNubTestCase
     }
 }
 
-
+// phpcs:ignore PSR1.Classes.ClassDeclaration
 class ListPushProvisionsExposed extends ListPushProvisions
 {
     protected $transport;

--- a/tests/functional/push/RemoveChannelsFromPushTest.php
+++ b/tests/functional/push/RemoveChannelsFromPushTest.php
@@ -58,14 +58,14 @@ class RemoveChannelsFromPushTest extends PubNubTestCase
         ], $remove->buildParams());
     }
 
-    public function testPushRemoveGoogle()
+    public function testPushRemoveFCM()
     {
         $this->pubnub->getConfiguration()->setUuid("sampleUUID");
 
         $remove = new RemoveChannelsFromPushExposed($this->pubnub);
 
         $remove->channels(['ch1', 'ch2', 'ch3'])
-            ->pushType(PNPushType::GCM)
+            ->pushType(PNPushType::FCM)
             ->deviceId('coolDevice');
 
         $this->assertEquals(sprintf(
@@ -77,13 +77,13 @@ class RemoveChannelsFromPushTest extends PubNubTestCase
         $this->assertEquals([
             "pnsdk" => PubNubUtil::urlEncode(PubNub::getSdkFullName()),
             "uuid" => $this->pubnub->getConfiguration()->getUuid(),
-            "type" => "gcm",
+            "type" => "fcm",
             "remove" => "ch1,ch2,ch3"
         ], $remove->buildParams());
     }
 }
 
-
+// phpcs:ignore PSR1.Classes.ClassDeclaration
 class RemoveChannelsFromPushExposed extends RemoveChannelsFromPush
 {
     public function buildParams()

--- a/tests/functional/push/RemoveDeviceFromPushTest.php
+++ b/tests/functional/push/RemoveDeviceFromPushTest.php
@@ -54,13 +54,13 @@ class RemoveDeviceFromPushTest extends PubNubTestCase
         ], $remove->buildParams());
     }
 
-    public function testRemovePushGCM()
+    public function testRemovePushFCM()
     {
         $this->pubnub->getConfiguration()->setUuid("sampleUUID");
 
         $remove = new RemoveDeviceFromPushExposed($this->pubnub);
 
-        $remove->pushType(PNPushType::GCM)
+        $remove->pushType(PNPushType::FCM)
             ->deviceId('coolDevice');
 
         $this->assertEquals(sprintf(
@@ -72,12 +72,12 @@ class RemoveDeviceFromPushTest extends PubNubTestCase
         $this->assertEquals([
             "pnsdk" => PubNubUtil::urlEncode(PubNub::getSdkFullName()),
             "uuid" => $this->pubnub->getConfiguration()->getUuid(),
-            "type" => "gcm",
+            "type" => "fcm",
         ], $remove->buildParams());
     }
 }
 
-
+// phpcs:ignore PSR1.Classes.ClassDeclaration
 class RemoveDeviceFromPushExposed extends RemoveDeviceFromPush
 {
     public function buildParams()

--- a/tests/integrational/ListPushProvisionsTest.php
+++ b/tests/integrational/ListPushProvisionsTest.php
@@ -8,7 +8,6 @@ use PubNub\Exceptions\PubNubValidationException;
 use PubNub\PubNub;
 use Tests\Helpers\StubTransport;
 
-
 class ListPushProvisionsTest extends \PubNubTestCase
 {
     public function testAppleSuccess()
@@ -32,7 +31,7 @@ class ListPushProvisionsTest extends \PubNubTestCase
         $this->assertInstanceOf(\PubNub\Models\Consumer\Push\PNPushListProvisionsResult::class, $response);
     }
 
-    public function testGoogleSuccess()
+    public function testFCMSuccess()
     {
         $this->pubnub->getConfiguration()->setUuid("sampleUUID");
 
@@ -40,14 +39,14 @@ class ListPushProvisionsTest extends \PubNubTestCase
 
         $list->stubFor("/v1/push/sub-key/demo/devices/coolDevice")
             ->withQuery([
-                "type" => "gcm",
+                "type" => "fcm",
                 "pnsdk" => $this->encodedSdkName,
                 "uuid" => "sampleUUID"
             ])
             ->setResponseBody("[\"ch1\", \"ch2\", \"ch3\"]");
 
         $response = $list->deviceId("coolDevice")
-            ->pushType(PNPushType::GCM)
+            ->pushType(PNPushType::FCM)
             ->sync();
 
         $this->assertInstanceOf(\PubNub\Models\Consumer\Push\PNPushListProvisionsResult::class, $response);
@@ -176,7 +175,7 @@ class ListPushProvisionsTest extends \PubNubTestCase
     }
 }
 
-
+// phpcs:ignore PSR1.Classes.ClassDeclaration
 class ListPushProvisionsExposed extends ListPushProvisions
 {
     protected $transport;

--- a/tests/integrational/ModifyPushChannelsForDeviceTest.php
+++ b/tests/integrational/ModifyPushChannelsForDeviceTest.php
@@ -10,7 +10,6 @@ use PubNub\Exceptions\PubNubValidationException;
 use PubNub\PubNub;
 use Tests\Helpers\StubTransport;
 
-
 class ModifyPushChannelsForDeviceTest extends \PubNubTestCase
 {
     public function testListChannelGroupAPNS()
@@ -34,7 +33,7 @@ class ModifyPushChannelsForDeviceTest extends \PubNubTestCase
         $this->assertInstanceOf(\PubNub\Models\Consumer\Push\PNPushRemoveAllChannelsResult::class, $response);
     }
 
-    public function testGoogleSuccessRemoveAll()
+    public function testFCMSuccessRemoveAll()
     {
         $this->pubnub->getConfiguration()->setUuid("sampleUUID");
 
@@ -42,13 +41,13 @@ class ModifyPushChannelsForDeviceTest extends \PubNubTestCase
 
         $listRemove->stubFor("/v1/push/sub-key/demo/devices/coolDevice/remove")
             ->withQuery([
-                "type" => "gcm",
+                "type" => "fcm",
                 "pnsdk" => $this->encodedSdkName,
                 "uuid" => "sampleUUID"
             ])
             ->setResponseBody("[1, \"Modified Channels\"]");
 
-        $response = $listRemove->pushType(PNPushType::GCM)
+        $response = $listRemove->pushType(PNPushType::FCM)
             ->deviceId("coolDevice")
             ->sync();
 
@@ -192,7 +191,7 @@ class ModifyPushChannelsForDeviceTest extends \PubNubTestCase
         $this->assertInstanceOf(\PubNub\Models\Consumer\Push\PNPushAddChannelResult::class, $response);
     }
 
-    public function testAddGoogleSuccessSync()
+    public function testAddFCMSuccessSync()
     {
         $this->pubnub->getConfiguration()->setUuid("sampleUUID");
 
@@ -201,13 +200,13 @@ class ModifyPushChannelsForDeviceTest extends \PubNubTestCase
         $listAdd->stubFor("/v1/push/sub-key/demo/devices/coolDevice")
             ->withQuery([
                 "add" => "ch1,ch2,ch3",
-                "type" => "gcm",
+                "type" => "fcm",
                 "pnsdk" => $this->encodedSdkName,
                 "uuid" => "sampleUUID"
             ])
             ->setResponseBody("[1, \"Modified Channels\"]");
 
-        $response = $listAdd->pushType(PNPushType::GCM)
+        $response = $listAdd->pushType(PNPushType::FCM)
             ->channels(["ch1", "ch2", "ch3"])
             ->deviceId("coolDevice")
             ->sync();
@@ -375,7 +374,7 @@ class ModifyPushChannelsForDeviceTest extends \PubNubTestCase
         $this->assertInstanceOf(\PubNub\Models\Consumer\Push\PNPushRemoveChannelResult::class, $response);
     }
 
-    public function testGoogleSuccessRemove()
+    public function testFCMSuccessRemove()
     {
         $this->pubnub->getConfiguration()->setUuid("sampleUUID");
 
@@ -384,13 +383,13 @@ class ModifyPushChannelsForDeviceTest extends \PubNubTestCase
         $remove->stubFor("/v1/push/sub-key/demo/devices/coolDevice")
             ->withQuery([
                 "remove" => "ch1,ch2,ch3",
-                "type" => "gcm",
+                "type" => "fcm",
                 "pnsdk" => $this->encodedSdkName,
                 "uuid" => "sampleUUID"
             ])
             ->setResponseBody("[1, \"Modified Channels\"]");
 
-        $response = $remove->pushType(PNPushType::GCM)
+        $response = $remove->pushType(PNPushType::FCM)
             ->channels(["ch1", "ch2", "ch3"])
             ->deviceId("coolDevice")
             ->sync();
@@ -544,7 +543,7 @@ class ModifyPushChannelsForDeviceTest extends \PubNubTestCase
     }
 }
 
-
+// phpcs:ignore PSR1.Classes.ClassDeclaration
 class RemoveChannelsFromPushTestExposed extends RemoveDeviceFromPush
 {
     protected $transport;
@@ -579,7 +578,7 @@ class RemoveChannelsFromPushTestExposed extends RemoveDeviceFromPush
     }
 }
 
-
+// phpcs:ignore PSR1.Classes.ClassDeclaration
 class AddChannelsToPushExposed extends AddChannelsToPush
 {
     protected $transport;
@@ -614,7 +613,7 @@ class AddChannelsToPushExposed extends AddChannelsToPush
     }
 }
 
-
+// phpcs:ignore PSR1.Classes.ClassDeclaration
 class RemovePushNotificationsFromChannelsExposed extends RemoveChannelsFromPush
 {
     protected $transport;

--- a/tests/integrational/ModifyPushChannelsForDeviceTest.php
+++ b/tests/integrational/ModifyPushChannelsForDeviceTest.php
@@ -347,7 +347,7 @@ class ModifyPushChannelsForDeviceTest extends \PubNubTestCase
         $listAdd = new AddChannelsToPushExposed($this->pubnub);
 
         $listAdd->pushType(PNPushType::MPNS)
-            ->deviceId("")
+            ->deviceId("Example")
             ->sync();
     }
 

--- a/tests/integrational/push/RemoveChannelsFromPushEndpointTest.php
+++ b/tests/integrational/push/RemoveChannelsFromPushEndpointTest.php
@@ -79,7 +79,7 @@ class RemoveChannelsFromPushEndpointTest extends \PubNubTestCase
         $this->assertNotEmpty($result);
     }
 
-    public function testPushRemoveGoogle()
+    public function testPushRemoveFCM()
     {
         $this->pubnub->getConfiguration()->setUuid("sampleUUID");
 
@@ -88,14 +88,14 @@ class RemoveChannelsFromPushEndpointTest extends \PubNubTestCase
         $remove->stubFor("/v1/push/sub-key/demo/devices/coolDevice")
             ->withQuery([
                 "pnsdk" => $this->encodedSdkName,
-                "type" => "gcm",
+                "type" => "fcm",
                 "uuid" => "sampleUUID",
                 "remove" => "ch1,ch2,ch3"
             ])
             ->setResponseBody('[1, "Modified Channels"]');
 
         $result = $remove->channels(['ch1', 'ch2', 'ch3'])
-            ->pushType(PNPushType::GCM)
+            ->pushType(PNPushType::FCM)
             ->deviceId('coolDevice')
             ->sync();
 
@@ -103,7 +103,7 @@ class RemoveChannelsFromPushEndpointTest extends \PubNubTestCase
     }
 }
 
-
+// phpcs:ignore PSR1.Classes.ClassDeclaration
 class RemoveChannelsFromPushEndpointExposed extends RemoveChannelsFromPush
 {
     protected $transport;


### PR DESCRIPTION
feat: Replace GCM with FCM

Replacing GCM with FCM. This is not a breaking change, but using GCM will result in throwing `E_USER_DEPRECATED` warning