### PR TITLE
Add missing changelog entry about history support and release immutable config

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -18,6 +18,8 @@ changelog:
     changes:
       - type: feature
         text: "Replacing GCM with FCM. This is not a breaking change, but using GCM will result in throwing `E_USER_DEPRECATED` warning."
+      - type: feature
+        text: "Added support for fetching messages"
   - date: 2023-11-27
     version: v6.1.3
     changes:
@@ -27,7 +29,7 @@ changelog:
     version: v6.1.2
     changes:
       - type: improvement
-        text: "Fix license info in composer.json" 
+        text: "Fix license info in composer.json"
   - date: 2023-10-30
     version: v6.1.1
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: php
-version: 6.3.0
+version: 7.0.0
 schema: 1
 scm: github.com/pubnub/php
 changelog:
+  - date: 2024-06-27
+    version: 7.0.0
+    changes:
+      - type: feature
+        text: "When passed to the `PubNub` constructor, the `PNConfiguration` instance becomes immutable. You can disable this behavior by calling `PnConfiguration::disableImmutableCheck()` before passing it to the constructor although it is not recommended. Disabling immutability may result in unpredictable behavior if `PNConfiguration` is modified after instantiating `PubNub`."
   - date: 2024-06-18
     version: v6.3.0
     changes:
@@ -424,8 +429,8 @@ sdks:
                     - x86-64
           - distribution-type: library
             distribution-repository: GitHub release
-            package-name: php-6.3.0.zip
-            location: https://github.com/pubnub/php/releases/tag/v6.3.0
+            package-name: php-7.0.0.zip
+            location: https://github.com/pubnub/php/releases/tag/7.0.0
             requires:
               - name: rmccue/requests
                 min-version: 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ June 11 2024
 
 #### Added
 - Replacing GCM with FCM. This is not a breaking change, but using GCM will result in throwing `E_USER_DEPRECATED` warning.
+- Added support to fetching messages endpoint
 
 ## v6.1.3
 November 27 2023
@@ -80,40 +81,40 @@ December 16 2021
 ## [v4.6.0](https://github.com/pubnub/php/releases/tag/v4.6.0)
 October-26-2021
 
-- 🌟️ Add support for Access Manager v3 with example. 
+- 🌟️ Add support for Access Manager v3 with example.
 
 ## [v4.5.0](https://github.com/pubnub/php/releases/tag/v4.5.0)
 August-24-2021
 
-- 🌟️ Missing PNPresenceEventResult getters added, dependency update. 
+- 🌟️ Missing PNPresenceEventResult getters added, dependency update.
 
 ## [v4.4.0](https://github.com/pubnub/php/releases/tag/v4.4.0)
 July-29-2021
 
-- 🌟️ Fix for wrong signature calculation mechanism added. 
+- 🌟️ Fix for wrong signature calculation mechanism added.
 
 ## [v4.3.0](https://github.com/pubnub/php/releases/tag/v4.3.0)
 March-29-2021
 
-- 🌟️ Add support for random initialization vector. 
+- 🌟️ Add support for random initialization vector.
 
 ## [v4.2.0](https://github.com/pubnub/php/releases/tag/v4.2.0)
 February-2-2021
 
-- 🌟️ Add support for device channel registration with apns2. 
-- 🌟️ Allows management of users and channels with metadata. 
-- 🌟️ Implement v2 signatures required for push and objects. 
-- 🌟️ Implement v2 grant endpoint with support for user level grant. 
+- 🌟️ Add support for device channel registration with apns2.
+- 🌟️ Allows management of users and channels with metadata.
+- 🌟️ Implement v2 signatures required for push and objects.
+- 🌟️ Implement v2 grant endpoint with support for user level grant.
 
 ## [v4.1.7](https://github.com/pubnub/php/releases/tag/v4.1.7)
 September-14-2020
 
-- 🌟️ Add delete permission support to grant call. 
+- 🌟️ Add delete permission support to grant call.
 
 ## [v4.1.6](https://github.com/pubnub/php/releases/tag/v4.1.6)
 August-20-2020
 
-- ⭐️️ Remove hard coded keys from tests. 
+- ⭐️️ Remove hard coded keys from tests.
 
 ## [v4.1.5](https://github.com/pubnub/php/tree/v4.1.5)
  October-22-2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+June 27 2024
+
+#### Added
+- When passed to the `PubNub` constructor, the `PNConfiguration` instance becomes immutable. You can disable this behavior by calling `PnConfiguration::disableImmutableCheck()` before passing it to the constructor although it is not recommended. Disabling immutability may result in unpredictable behavior if `PNConfiguration` is modified after instantiating `PubNub`.
+
 ## v6.3.0
 June 18 2024
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
          {
              "require": {
                  <!-- include the latest version from the badge at the top -->
-                 "pubnub/pubnub": "6.3.0"
+                 "pubnub/pubnub": "7.0.0"
              }
          }
          ```

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["api", "real-time", "realtime", "real time", "ajax", "push"],
   "homepage": "http://www.pubnub.com/",
   "license": "proprietary",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "authors": [
     {
       "name": "PubNub",

--- a/src/PubNub/PubNub.php
+++ b/src/PubNub/PubNub.php
@@ -56,7 +56,7 @@ use PubNub\Endpoints\FileSharing\{SendFile, DeleteFile, DownloadFile, GetFileDow
 
 class PubNub implements LoggerAwareInterface
 {
-    protected const SDK_VERSION = "6.3.0";
+    protected const SDK_VERSION = "7.0.0";
     protected const SDK_NAME = "PubNub-PHP";
 
     public static $MAX_SEQUENCE = 65535;


### PR DESCRIPTION
feat: Immutable config (potentially breaking change)
When passed to the `PubNub` constructor, the `PNConfiguration` instance becomes immutable. You can disable this behavior by calling `PnConfiguration::disableImmutableCheck()` before passing it to the constructor although it is not recommended. Disabling immutability may result in unpredictable behavior if `PNConfiguration` is modified after instantiating `PubNub`.