### PR TITLE
Add setType method to SetChannelMetadata

### DIFF
--- a/src/PubNub/Endpoints/Objects/Channel/SetChannelMetadata.php
+++ b/src/PubNub/Endpoints/Objects/Channel/SetChannelMetadata.php
@@ -77,6 +77,16 @@ class SetChannelMetadata extends Endpoint
     }
 
     /**
+     * @param string $type
+     * @return $this
+     */
+    public function setType($type): self
+    {
+        $this->meta['type'] = $type;
+        return $this;
+    }
+
+    /**
      * @throws PubNubValidationException
      */
     protected function validateParams()


### PR DESCRIPTION
Because `->meta(['type' => 'some type'])` is deprecated