### PR TITLE
Fix logical operator for member and UUID checks

### DIFF
--- a/src/PubNub/Endpoints/Objects/Member/ManageMembers.php
+++ b/src/PubNub/Endpoints/Objects/Member/ManageMembers.php
@@ -147,8 +147,8 @@ class ManageMembers extends ObjectsCollectionEndpoint
         if (empty($this->channel)) {
             throw new PubNubValidationException("channel missing");
         }
-        $members = !empty($this->setMembers) or !empty($this->removeMembers);
-        $uuids = !empty($this->setUuids) or !empty($this->removeUuids);
+        $members = !empty($this->setMembers) || !empty($this->removeMembers);
+        $uuids = !empty($this->setUuids) || !empty($this->removeUuids);
 
         if ($members and $uuids) {
             throw new PubNubValidationException("Either members or uuids should be provided");


### PR DESCRIPTION
It does not work the way it may look at first glance because of operator precedence (https://www.php.net/manual/en/language.operators.precedence.php )

`or` is called after the assignment `=`
`||` is called before the assignment =

It is interpreted as:

```
($members = !empty($this->setMembers)) or !empty($this->removeMembers);
```

So if:

$this->setMembers has 0 elements → empty(...) is true → !empty(...) is false $this->removeMembers has 1 element → !empty(...) is true

Then:

$members = false;